### PR TITLE
added configurable endpoint for message type, allowing notification

### DIFF
--- a/src/HipchatGateway.php
+++ b/src/HipchatGateway.php
@@ -89,7 +89,9 @@ class HipchatGateway implements GatewayInterface
 
         $params['color'] = $color;
 
-        return $this->send($this->buildUrlFromString("room/{$to}/message"), $params);
+        $type = Arr::get($this->config, 'type', 'message');
+
+        return $this->send($this->buildUrlFromString("room/{$to}/{$type}"), $params);
     }
 
     /**


### PR DESCRIPTION
By forcing the endpoint to message you will always have to use a personal access token. Having made this configurable it is now possible to use type notification and use a simple room access token instead.

https://www.hipchat.com/docs/apiv2/method/send_room_notification
